### PR TITLE
Use buffer dimensions instead of "getWidth", "getHeight", and "getDepth"

### DIFF
--- a/python/clijpy_demo.ipynb
+++ b/python/clijpy_demo.ipynb
@@ -146,7 +146,7 @@
     "\n",
     "def clijx_pull(buffer):\n",
     "    import numpy\n",
-    "    numpy_image = numpy.zeros([buffer.getWidth(), buffer.getHeight(), buffer.getDepth()])\n",
+    "    numpy_image = numpy.zeros(np.flip(buffer.dimensions))\n",
     "    wrapped = ij.py.to_java(numpy_image);\n",
     "    clijx.pullToRAI(buffer, wrapped);\n",
     "    return numpy_image\n",


### PR DESCRIPTION
Described in issue #5 

When trying to reproduce the example notebook in google colab the buffer objects do not have the getWidth, getHeight, getDepth attributes.